### PR TITLE
fix case where out is provided as model eval input

### DIFF
--- a/grama/core.py
+++ b/grama/core.py
@@ -1052,10 +1052,14 @@ class Model:
 
         """
         ## Check invariant; model inputs must be subset of df columns
-        if not set(self.var).issubset(set(df.columns)):
-            raise ValueError("Model inputs not a subset of given columns")
+        var_diff = set(self.var).difference(set(df.columns))
+        if len(var_diff) != 0:
+            raise ValueError(
+                "Model inputs not a subset of given columns;\n"
+                + "missing var = {}".format(var_diff)
+            )
 
-        df_tmp = df.copy()
+        df_tmp = df.copy().drop(self.out, axis=1, errors="ignore")
         ## Evaluate each function
         for func in self.functions:
             ## Concatenate to make intermediate results available

--- a/grama/eval_defaults.py
+++ b/grama/eval_defaults.py
@@ -46,11 +46,23 @@ def eval_df(model, df=None, append=True):
         raise ValueError("No input df given")
     if len(model.functions) == 0:
         raise ValueError("Given model has no functions")
+    out_intersect = set(df.columns).intersection(model.out)
+    if len(out_intersect) > 0:
+        print(
+            "... provided columns intersect model output.\n"
+            + "eval_df() is dropping {}".format(out_intersect)
+        )
 
     df_res = model.evaluate_df(df)
 
     if append:
-        df_res = concat([df.reset_index(drop=True), df_res], axis=1)
+        df_res = concat(
+            [
+                df.reset_index(drop=True).drop(model.out, axis=1, errors="ignore"),
+                df_res,
+            ],
+            axis=1,
+        )
 
     return df_res
 


### PR DESCRIPTION
Modify Model implementation and eval_df to handle the case where a model's
outputs are provided as DataFrame columns. Drop these extra columns and print to
console which columns are dropped.