### PR TITLE
Fix drop out

### DIFF
--- a/grama/comp_building.py
+++ b/grama/comp_building.py
@@ -57,10 +57,23 @@ def _comp_function_data(model, fun, var, out, name, runtime):
         raise ValueError("`out` must be list or int")
 
     # Check DAG invariants
-    if len(set(out).intersection(set(model.var))) > 0:
-        raise ValueError("`out` must not intersect model.var")
-    if len(set(out).intersection(set(model.out))) > 0:
-        raise ValueError("`out` must not intersect model.out")
+    args_inter = set(out).intersection(set(var))
+    if len(args_inter) > 0:
+        raise ValueError(
+            "`out` must not intersect `var`\n" + "intersection = {}".format(args_inter)
+        )
+    out_var_inter = set(out).intersection(set(model.var))
+    if len(out_var_inter) > 0:
+        raise ValueError(
+            "`out` must not intersect model.var"
+            + "intersection = {}".format(out_var_inter)
+        )
+    out_out_inter = set(out).intersection(set(model.out))
+    if len(out_out_inter) > 0:
+        raise ValueError(
+            "`out` must not intersect model.out"
+            + "intersection = {}".format(out_out_inter)
+        )
 
     return fun, var, out, name, runtime
 

--- a/grama/core.py
+++ b/grama/core.py
@@ -1052,10 +1052,14 @@ class Model:
 
         """
         ## Check invariant; model inputs must be subset of df columns
-        if not set(self.var).issubset(set(df.columns)):
-            raise ValueError("Model inputs not a subset of given columns")
+        var_diff = set(self.var).difference(set(df.columns))
+        if len(var_diff) != 0:
+            raise ValueError(
+                "Model inputs not a subset of given columns;\n"
+                + "missing var = {}".format(var_diff)
+            )
 
-        df_tmp = df.copy()
+        df_tmp = df.copy().drop(self.out, axis=1, errors="ignore")
         ## Evaluate each function
         for func in self.functions:
             ## Concatenate to make intermediate results available

--- a/grama/eval_defaults.py
+++ b/grama/eval_defaults.py
@@ -46,11 +46,23 @@ def eval_df(model, df=None, append=True):
         raise ValueError("No input df given")
     if len(model.functions) == 0:
         raise ValueError("Given model has no functions")
+    out_intersect = set(df.columns).intersection(model.out)
+    if len(out_intersect) > 0:
+        print(
+            "... provided columns intersect model output.\n"
+            + "eval_df() is dropping {}".format(out_intersect)
+        )
 
     df_res = model.evaluate_df(df)
 
     if append:
-        df_res = concat([df.reset_index(drop=True), df_res], axis=1)
+        df_res = concat(
+            [
+                df.reset_index(drop=True).drop(model.out, axis=1, errors="ignore"),
+                df_res,
+            ],
+            axis=1,
+        )
 
     return df_res
 

--- a/tests/test_mbi.py
+++ b/tests/test_mbi.py
@@ -66,6 +66,9 @@ class TestMBI(unittest.TestCase):
             # Missing out
             gr.comp_function(self.md, fun=lambda x: x, var=["foo"], out=None)
         with self.assertRaises(ValueError):
+            # Intersection var / out names
+            self.md >> gr.cp_function(lambda x: x, var=["x"], out=["x"], name="f0")
+        with self.assertRaises(ValueError):
             # Non-unique function names
             self.md >> gr.cp_function(
                 lambda x: x, var=1, out=1, name="f0"


### PR DESCRIPTION
Fix invalid model implementation:

- When evaluating a Model with a DataFrame, automatically drop columns that intersect the Model's out; print a note to console
- When building a model, check that `var` and `out` do not intersect
- Provide debug information when checking model building invariants