### PR TITLE
deprecate tran_transmute()

### DIFF
--- a/grama/dfply/transform.py
+++ b/grama/dfply/transform.py
@@ -3,8 +3,6 @@ __all__ = [
     "tf_mutate",
     "tran_mutate_if",
     "tf_mutate_if",
-    "tran_transmute",
-    "tf_transmute",
 ]
 
 from .base import dfdelegate, make_symbolic, flatten
@@ -72,46 +70,3 @@ def tran_mutate_if(df, predicate, fun):
     # return df2
 
 tf_mutate_if = add_pipe(tran_mutate_if)
-
-
-@dfdelegate
-def tran_transmute(df, *keep_columns, **kwargs):
-    """
-    Creates columns and then returns those new columns and optionally specified
-    original columns from the DataFrame.
-
-    This works like `mutate`, but designed to discard the original columns used
-    to create the new ones.
-
-    Args:
-        *keep_columns: Column labels to keep. Can be string, symbolic, or
-            integer position.
-
-    Kwargs:
-        **kwargs: keys are the names of the new columns, values indicate
-            what the new column values will be.
-
-    Example:
-        diamonds >> transmute(x_plus_y=X.x + X.y, y_div_z=(X.y / X.z)) >> head(3)
-
-            y_div_z  x_plus_y
-        0  1.637860      7.93
-        1  1.662338      7.73
-        2  1.761905      8.12
-    """
-
-    keep_cols = []
-    for col in flatten(keep_columns):
-        try:
-            keep_cols.append(col.name)
-        except:
-            if isinstance(col, str):
-                keep_cols.append(col)
-            elif isinstance(col, int):
-                keep_cols.append(df.columns[col])
-
-    df = df.assign(**kwargs)
-    columns = [k for k in kwargs.keys()] + list(keep_cols)
-    return df[columns]
-
-tf_transmute = add_pipe(tran_transmute)

--- a/tests/test_dfply_transform.py
+++ b/tests/test_dfply_transform.py
@@ -40,25 +40,6 @@ class testTransform(unittest.TestCase):
         )
         self.assertTrue(df.equals(d.sort_index()))
 
-    def test_transmute(self):
-        df = data.df_diamonds.copy()
-        df["testcol"] = df["x"] * df["y"]
-        df = df[["testcol"]]
-        self.assertTrue(
-            df.equals(data.df_diamonds >> gr.tf_transmute(testcol=X.x * X.y))
-        )
-
-    def test_group_transmute(self):
-        df = data.df_diamonds.copy()
-        df = df.groupby("cut").apply(group_mutate_helper).reset_index(drop=True)
-        df = df[["cut", "testcol"]]
-        d = (
-            data.df_diamonds
-            >> gr.tf_group_by("cut")
-            >> gr.tf_transmute(testcol=X.x * X.shape[0])
-        )
-        self.assertTrue(df.equals(d.sort_index()))
-
     def test_mutate_if(self):
         df = data.df_diamonds.copy()
         for col in df:


### PR DESCRIPTION
`tran_transmute()` was broken by [Pandas 1.4.0](https://pandas.pydata.org/pandas-docs/stable/whatsnew/index.html#version-1-4). Since this is not a common verb, I'm deprecating it.