### PR TITLE
Fix runtime est

### DIFF
--- a/grama/core.py
+++ b/grama/core.py
@@ -825,6 +825,8 @@ class Model:
             domain = Domain()
         if density is None:
             density = Density()
+        if name is None:
+            name = "(no name)"
 
         self.name = name
         self.functions = functions
@@ -886,7 +888,7 @@ class Model:
         for fun in self.functions:
             rate = rate + fun.runtime
 
-        return rate * n
+        return float(rate * n)
 
     def runtime_message(self, df):
         """Runtime message

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -123,7 +123,7 @@ class TestRandomSampling(unittest.TestCase):
     def setUp(self):
         self.md = (
             gr.Model()
-            >> gr.cp_function(fun=lambda x: x, var=1, out=1)
+            >> gr.cp_function(fun=lambda x: x, var=1, out=1, runtime=1)
             >> gr.cp_marginals(x0={"dist": "uniform", "loc": 0, "scale": 1})
             >> gr.cp_copula_independence()
         )


### PR DESCRIPTION
Bugfix: Identified error where setting `skip=True` in `gr.eval_sample()` could raise an exception. Modified `gr.Model()` to provide a print-safe `name` attribute and to case `runtime` for print-safety.