### PR TITLE
Dev Python versioning & testing

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,13 +13,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,9 +18,9 @@ jobs:
         python-version: ["3.8", "3.9"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -37,6 +37,6 @@ jobs:
         coverage xml
         mv coverage.xml ../. # Move coverage file for upload to Codecov
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: false

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8, <3.10",
     install_requires=[
         "matplotlib",
         "numpy>=1.15",


### PR DESCRIPTION
Updating compabitilty for Python Versions and testing. Addresses initial concerns brought up in Issue #186 . Establishes official support & testing for both Python 3.8 & 3.9. 

Changes:
- Update python-app.yml to perform testing on both Python 3.8 & 3.9
- Update python-app.yml to use the newer checkout@v3 and setup-python@v3 (updated from v2)
- Update setup.py to reflect the officially supported 3.8 & 3.9 versions.

Other information:
- I chose to just test on 3.8 & 3.9 as Python 3.6 and earlier are now deprecated. I don't believe it is high priority to support now deprecated versions of Python, as other packages (i.e. grama dependencies) do not appear to be. Adding 3.10, and eventually 3.11, support is more important.
- Python 3.10 should be added to the test suite as soon as it can be fully supported. 
- Testing ('''make test'''') takes roughly 50 seconds for each Python version (locally tested). 
- The actions all passed and worked properly on my forked repo.