### PR TITLE
Dev form inputs

### DIFF
--- a/grama/eval_tail.py
+++ b/grama/eval_tail.py
@@ -12,6 +12,7 @@ from numpy import array, argmin, ones, eye, zeros, sqrt, NaN, max
 from numpy.linalg import norm as length
 from numpy.random import multivariate_normal
 from pandas import DataFrame, concat
+from scipy.stats import norm
 from scipy.optimize import minimize
 from toolz import curry
 
@@ -35,6 +36,8 @@ def make_T(model, df_corr):
 def eval_form_pma(
     model,
     betas=None,
+    rels=None,
+    pofs=None,
     cons=None,
     df_corr=None,
     df_det=None,
@@ -46,20 +49,29 @@ def eval_form_pma(
 ):
     r"""Tail quantile via FORM PMA
 
-    Approximate the desired tail quantiles using the performance measure approach (PMA) of the first-order reliability method (FORM) [1]. Select limit states to minimize at desired quantile with `betas`. Provide confidence levels `cons` and estimator covariance `df_corr` to compute with margin in beta [2].
+    Approximate the desired tail quantiles using the performance measure approach (PMA) of the first-order reliability method (FORM) [1]. Select limit states to minimize at desired quantile with one of: `betas` (reliability indices), `rels` (reliability values), or `pofs` (probabilities of failure). Provide confidence levels `cons` and estimator covariance `df_corr` to compute with margin in beta [2].
 
     Note that under the performance measure approach, the optimized limit state value `g` is sought to be non-negative $g \geq 0$. This is usually included as a constraint in optimization, which can be accomplished in by using ``gr.eval_form_pnd()` *within* a model definition---see the Examples below for more details.
 
     Args:
         model (gr.Model): Model to analyze
+        df_det (DataFrame): Deterministic levels for evaluation; use "nom" for nominal deterministic levels.
+
         betas (dict): Target reliability indices;
             key   = limit state name; must be in model.out
             value = reliability index; beta = Phi^{-1}(reliability)
+        rels (dict): Target reliability values;
+            key   = limit state name; must be in model.out
+            value = reliability
+        pofs (dict): Target probabilities of failure (POFs);
+            key   = limit state name; must be in model.out
+            value = probability of failure; pof = 1 - reliability
+
         cons (dict or None): Target confidence levels;
             key   = limit state name; must be in model.out
             value = confidence level, \in (0, 1)
         df_corr (DataFrame or None): Sampling distribution covariance entries; parameters with no information assumed to be known exactly.
-        df_det (DataFrame): Deterministic levels for evaluation; use "nom" for nominal deterministic levels.
+
         n_maxiter (int): Maximum iterations for each optimization run
         n_restart (int): Number of restarts (== number of optimization runs)
         append (bool): Append MPP results for random values?
@@ -86,6 +98,17 @@ def eval_form_pma(
             >> gr.ev_form_pma(
                 # Specify target reliability
                 betas=dict(g_stress=3, g_disp=3),
+                # Analyze three different thicknesses
+                df_det=gr.df_make(t=[2, 3, 4], w=3)
+            )
+        )
+
+        ## Specify reliability in POF form
+        (
+            md_beam
+            >> gr.ev_form_pma(
+                # Specify target reliability
+                pofs=dict(g_stress=1e-3, g_disp=1e-3),
                 # Analyze three different thicknesses
                 df_det=gr.df_make(t=[2, 3, 4], w=3)
             )
@@ -127,10 +150,22 @@ def eval_form_pma(
     invariants_eval_model(model)
     invariants_eval_df(df_corr, arg_name="df_corr", acc_none=True)
     invariants_eval_df(df_det, arg_name="df_det", valid_str=["nom"])
-    if betas is None:
+    # Check that reliability targets given by one argument only
+    if all((betas is None, rels is None, pofs is None)):
         raise ValueError(
-            "Must provide `betas` keyword argument to define reliability targets"
+            "Must provide reliability targets as keyword argument `betas`, `rels`, OR `pofs`"
         )
+    if sum((betas is not None, rels is not None, pofs is not None)) > 1:
+        raise ValueError(
+            "Must provide *only* one of `betas`, `rels`, OR `pofs`"
+        )
+    # Convert reliability targets to `betas`
+    if rels is not None:
+        betas = {k: norm.ppf(v) for (k, v) in rels.items()}
+    if pofs is not None:
+        betas = {k: norm.ppf(1 - v) for (k, v) in pofs.items()}
+
+    # Check `betas` invariants
     if not set(betas.keys()).issubset(set(model.out)):
         raise ValueError("betas.keys() must be subset of model.out")
     if not cons is None:

--- a/grama/eval_tail.py
+++ b/grama/eval_tail.py
@@ -295,7 +295,7 @@ def eval_form_ria(
 ):
     r"""Tail reliability via FORM RIA
 
-    Approximate the desired tail probability using the reliability index approach (RIA) of the first-order reliability method (FORM) [1]. Select limit states to analyze with list input `limits`. Provide confidence levels `cons` and estimator covariance `df_corr` to compute with margin in beta [2].
+    Approximate the desired tail probability using the reliability index approach (RIA) of the first-order reliability method (FORM) [1]. Select limit states to analyze with list input `limits`. Choose output type using `format` argument (`betas` for reliability indices, `rels` for realibility values, `pofs` for probabilify of failure values). Provide confidence levels `cons` and estimator covariance `df_corr` to compute with margin in beta [2].
 
     Note that the reliability index approach (RIA) is generally less stable than the performance measure approach (PMA). Consider using ``gr.eval_form_pma()`` instead, particularly when using FORM to optimize a design.
 

--- a/tests/test_tail.py
+++ b/tests/test_tail.py
@@ -72,6 +72,30 @@ class TestFORM(unittest.TestCase):
         )
         self.assertTrue(df_beam.shape[0] == 1)
 
+        ## Test other outputs
+        limits = ["g_stress", "g_disp"]
+        beta_names = ["beta_g_stress", "beta_g_disp"]
+        # Return reliabilities
+        df_rels = self.md_beam >> gr.ev_form_ria(
+            df_det="nom", limits=limits, append=False, format="rels",
+        )
+        self.assertTrue(gr.df_equal(
+            df_beam.apply(lambda col: norm.cdf(col) if col.name in beta_names else col) \
+                   .rename(columns={"beta_" + s: "rel_" + s for s in limits}),
+            df_rels,
+            close=True,
+        ))
+        # Return POFs
+        df_pofs = self.md_beam >> gr.ev_form_ria(
+            df_det="nom", limits=limits, append=False, format="pofs",
+        )
+        self.assertTrue(gr.df_equal(
+            df_beam.apply(lambda col: 1-norm.cdf(col) if col.name in beta_names else col) \
+                   .rename(columns={"beta_" + s: "pof_" + s for s in limits}),
+            df_pofs,
+            close=True,
+        ))
+
     def test_pma(self):
         ## Test accuracy
         df_res = self.md >> gr.ev_form_pma(df_det="nom", betas=dict(g=self.beta_true))

--- a/tests/test_tail.py
+++ b/tests/test_tail.py
@@ -80,7 +80,7 @@ class TestFORM(unittest.TestCase):
             df_det="nom", limits=limits, append=False, format="rels",
         )
         self.assertTrue(gr.df_equal(
-            df_beam.apply(lambda col: norm.cdf(col) if col.name in beta_names else col) \
+            df_beam.apply(lambda col: norm.cdf(col) if col.name in beta_names else col)
                    .rename(columns={"beta_" + s: "rel_" + s for s in limits}),
             df_rels,
             close=True,
@@ -90,7 +90,7 @@ class TestFORM(unittest.TestCase):
             df_det="nom", limits=limits, append=False, format="pofs",
         )
         self.assertTrue(gr.df_equal(
-            df_beam.apply(lambda col: 1-norm.cdf(col) if col.name in beta_names else col) \
+            df_beam.apply(lambda col: 1-norm.cdf(col) if col.name in beta_names else col)
                    .rename(columns={"beta_" + s: "pof_" + s for s in limits}),
             df_pofs,
             close=True,

--- a/tests/test_tail.py
+++ b/tests/test_tail.py
@@ -88,3 +88,15 @@ class TestFORM(unittest.TestCase):
             df_det="nom", betas={"g_stress": 3, "g_disp": 3}, append=False,
         )
         self.assertTrue(df_beam.shape[0] == 1)
+
+        ## Specify reliabilities
+        df_rels = self.md_beam >> gr.ev_form_pma(
+            df_det="nom", rels={"g_stress": norm.cdf(3), "g_disp": norm.cdf(3)}, append=False,
+        )
+        self.assertTrue(gr.df_equal(df_beam, df_rels, close=True))
+
+        ## Specify POFs
+        df_pofs = self.md_beam >> gr.ev_form_pma(
+            df_det="nom", pofs={"g_stress": 1 - norm.cdf(3), "g_disp": 1 - norm.cdf(3)}, append=False,
+        )
+        self.assertTrue(gr.df_equal(df_beam, df_pofs, close=True))


### PR DESCRIPTION
Add features to FORM utilities:

- allow user to specify return type for reliability information from `eval_form_ria()` using `format` argument; now supports returning reliability or probability of failure (POF)
- allow user to specify target reliability for `eval_form_pma()` as reliability values `rels` or probability of failure values `pofs`
- add unittest coverage for new features