### PR TITLE
Fix freeze density

### DIFF
--- a/grama/comp_building.py
+++ b/grama/comp_building.py
@@ -141,6 +141,16 @@ def comp_freeze(model, df=None, **var):
     # Remove bounds, if they exist
     for k in var.keys():
         model_new.domain.bounds.pop(k, None)
+    # Remove marginals, if they exist
+    for k in var.keys():
+        model_new.density.marginals.pop(k, None)
+    # Reset copula
+    model_new.density = Density(
+        marginals=model_new.density.marginals,
+        copula=CopulaIndependence(model_new.var_rand),
+    )
+    print("... comp_freeze() is resetting copula to independence copula")
+
     # Add new functions
     model_new.functions.insert(0, f)
     # Update before return

--- a/tests/test_mbi.py
+++ b/tests/test_mbi.py
@@ -58,6 +58,9 @@ class TestMBI(unittest.TestCase):
         df_res = gr.eval_df(md_frz, gr.df_make(y=[0, 1], z=0))
         self.assertTrue(all(df_res["x"] == 0))
 
+        # Can still sample
+        df_samp = gr.eval_sample(md_frz, df_det="nom", n=10)
+
         # Freezing non-existent variables raises error
         with self.assertRaises(ValueError):
             gr.comp_freeze(md_base, foo=0)


### PR DESCRIPTION
Fix an issue with comp_freeze() that left random variables listed as inputs: Remove marginals of frozen variables and reset to independence copula.