### PR TITLE
deprecate tran_poly

### DIFF
--- a/grama/tran/tran_scikitlearn.py
+++ b/grama/tran/tran_scikitlearn.py
@@ -1,14 +1,14 @@
 __all__ = [
     "tran_tsne",
     "tf_tsne",
-    "tran_poly",
-    "tf_poly",
+    # "tran_poly",
+    # "tf_poly",
 ]
 
 ## Transforms via sklearn package
 try:
     from sklearn.manifold import TSNE
-    from sklearn.preprocessing import PolynomialFeatures
+    # from sklearn.preprocessing import PolynomialFeatures
 
 except ModuleNotFoundError:
     pass
@@ -103,67 +103,67 @@ def tran_tsne(
 tf_tsne = add_pipe(tran_tsne)
 
 # --------------------------------------------------
-@curry
-def tran_poly(df, degree=None, var=None, keep=True, **kwargs):
-    r"""Compute polynomial features of a dataset
+# @curry
+# def tran_poly(df, degree=None, var=None, keep=True, **kwargs):
+#     r"""Compute polynomial features of a dataset
 
-    Compute polynomial features of a dataset.
+#     Compute polynomial features of a dataset.
 
-    Args:
-        df (DataFrame): Hybrid point results from gr.eval_hybrid()
+#     Args:
+#         df (DataFrame): Hybrid point results from gr.eval_hybrid()
 
-    Kwargs:
-        degree (int): Maximum degree of polynomial features
-        var (list or None): Variables in df on which to perform dimension reduction.
-            Use None to compute with all variables.
-        keep (bool): Keep unused columns (outside `var`) in new DataFrame?
-        interaction_only (bool): If true, only produce interaction features
-        include_bias (bool): If true, include a constant feature term (bias)
+#     Kwargs:
+#         degree (int): Maximum degree of polynomial features
+#         var (list or None): Variables in df on which to perform dimension reduction.
+#             Use None to compute with all variables.
+#         keep (bool): Keep unused columns (outside `var`) in new DataFrame?
+#         interaction_only (bool): If true, only produce interaction features
+#         include_bias (bool): If true, include a constant feature term (bias)
 
-    Notes:
-        - A wrapper for sklearn.preprocessing.PolynomialFeatures
+#     Notes:
+#         - A wrapper for sklearn.preprocessing.PolynomialFeatures
 
-    References:
-        Scikit-learn: Machine Learning in Python, Pedregosa et al. JMLR 12, pp. 2825-2830, 2011.
+#     References:
+#         Scikit-learn: Machine Learning in Python, Pedregosa et al. JMLR 12, pp. 2825-2830, 2011.
 
-    Examples:
+#     Examples:
 
-    """
-    ## Check invariants
-    if var is None:
-        var = list(df.columns).copy()
-    else:
-        var = list(var).copy()
-        diff = set(var).difference(set(df.columns))
-        if len(diff) > 0:
-            raise ValueError(
-                "`var` must be subset of `df.columns`\n" "diff = {}".format(diff)
-            )
-    var_leftover = list(set(df.columns).difference(set(var)))
+#     """
+#     ## Check invariants
+#     if var is None:
+#         var = list(df.columns).copy()
+#     else:
+#         var = list(var).copy()
+#         diff = set(var).difference(set(df.columns))
+#         if len(diff) > 0:
+#             raise ValueError(
+#                 "`var` must be subset of `df.columns`\n" "diff = {}".format(diff)
+#             )
+#     var_leftover = list(set(df.columns).difference(set(var)))
 
-    ## Compute the features
-    try:
-        fit = PolynomialFeatures(degree)
+#     ## Compute the features
+#     try:
+#         fit = PolynomialFeatures(degree)
 
-    except NameError as e:
-        error_string = str(e)
-        raise NameError(
-            error_string +
-            "\n\nThis function requires the `sklearn` package. " +
-            "Try running the following to install the package:\n"
-            "    pip install scikit-learn"
-        )
+#     except NameError as e:
+#         error_string = str(e)
+#         raise NameError(
+#             error_string +
+#             "\n\nThis function requires the `sklearn` package. " +
+#             "Try running the following to install the package:\n"
+#             "    pip install scikit-learn"
+#         )
 
-    X_feat = fit.fit_transform(df[var].values)
-    var_feat = fit.get_feature_names(var)
+#     X_feat = fit.fit_transform(df[var].values)
+#     var_feat = ["poly{}".format(i) for i in range(X_feat.shape[1])]
 
-    ## Package results
-    df_feat = DataFrame(data=X_feat, columns=var_feat)
+#     ## Package results
+#     df_feat = DataFrame(data=X_feat, columns=var_feat)
 
-    if keep:
-        return concat((df_feat, df[var_leftover].reset_index(drop=True)), axis=1)
+#     if keep:
+#         return concat((df_feat, df[var_leftover].reset_index(drop=True)), axis=1)
 
-    return df_feat
+#     return df_feat
 
 
-tf_poly = add_pipe(tran_poly)
+# tf_poly = add_pipe(tran_poly)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -384,20 +384,20 @@ class TestDR(unittest.TestCase):
 
 
 # --------------------------------------------------
-class TestFeaturize(unittest.TestCase):
-    def setUp(self):
-        pass
+# class TestFeaturize(unittest.TestCase):
+#     def setUp(self):
+#         pass
 
-    def test_tran_poly(self):
-        df = gr.df_make(x=[0.0, 1.0, 0.0], y=[0.0, 0.0, 1.0], z=[1.0, 2.0, 3.0],)
-        df_true = df.copy()
-        df_true["1"] = [1.0, 1.0, 1.0]
-        df_true["x^2"] = [0.0, 1.0, 0.0]
-        df_true["x y"] = [0.0, 0.0, 0.0]
-        df_true["y^2"] = [0.0, 0.0, 1.0]
+#     def test_tran_poly(self):
+#         df = gr.df_make(x=[0.0, 1.0, 0.0], y=[0.0, 0.0, 1.0], z=[1.0, 2.0, 3.0],)
+#         df_true = df.copy()
+#         df_true["1"] = [1.0, 1.0, 1.0]
+#         df_true["x^2"] = [0.0, 1.0, 0.0]
+#         df_true["x y"] = [0.0, 0.0, 0.0]
+#         df_true["y^2"] = [0.0, 0.0, 1.0]
 
-        df_res = gr.tran_poly(df, var=["x", "y"], degree=2, keep=True)
-        self.assertTrue(gr.df_equal(df_true, df_res[df_true.columns]))
+#         df_res = gr.tran_poly(df, var=["x", "y"], degree=2, keep=True)
+#         self.assertTrue(gr.df_equal(df_true, df_res[df_true.columns]))
 
 
 # --------------------------------------------------


### PR DESCRIPTION
tran_poly() routine relied on now-deprecated get_feature_names() routine in sklearn. Deprecate tran_poly() until we can implement our own version, likely as a composition and transform.