### PR TITLE
import real from numpy for scipy deprecation

### DIFF
--- a/grama/models/sir.py
+++ b/grama/models/sir.py
@@ -4,7 +4,7 @@ import grama as gr
 
 from scipy.integrate import solve_ivp
 from scipy.special import lambertw
-from scipy import real
+from numpy import real
 from toolz import curry
 
 DF = gr.Intention()


### PR DESCRIPTION
The latest version of `scipy` no longer provides `real`; import this from `numpy` instead.